### PR TITLE
TestNewRadX: Sync state after rhs calculation

### DIFF
--- a/TestNewRadX/schedule.ccl
+++ b/TestNewRadX/schedule.ccl
@@ -28,7 +28,6 @@ SCHEDULE TestNewRadX_RHS IN ODESolvers_RHS
   LANG: C
   READS: state(everywhere)
   WRITES: rhs(interior)
-  SYNC: rhs
 } "Calculate scalar wave RHS"
 
 SCHEDULE TestNewRadX_Sync IN ODESolvers_PostStep

--- a/TestNewRadX/schedule.ccl
+++ b/TestNewRadX/schedule.ccl
@@ -31,6 +31,13 @@ SCHEDULE TestNewRadX_RHS IN ODESolvers_RHS
   SYNC: rhs
 } "Calculate scalar wave RHS"
 
+SCHEDULE TestNewRadX_Sync IN ODESolvers_PostStep
+{
+  LANG: C
+  OPTIONS: global
+  SYNC: state
+} "Synchronize"
+
 SCHEDULE TestNewRadX_CompareSolution IN ODESolvers_PostStep
 {
   LANG: C

--- a/TestNewRadX/src/test_newradx.cxx
+++ b/TestNewRadX/src/test_newradx.cxx
@@ -129,6 +129,10 @@ extern "C" void TestNewRadX_RHS(CCTK_ARGUMENTS) {
   }
 }
 
+extern "C" void TestNewRadX_Sync(CCTK_ARGUMENTS) {
+  // do nothing
+}
+
 extern "C" void TestNewRadX_CompareSolution(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTSX_TestNewRadX_CompareSolution;
   DECLARE_CCTK_PARAMETERS;


### PR DESCRIPTION
This will fix the CI test failure catches by commit `1fda697` `ODESolvers: Solve only in the interior` of CarpetX