### PR TITLE
Z4c: fix typo in calculating HC and MtC

### DIFF
--- a/Z4c/src/z4c_vars.hxx
+++ b/Z4c/src/z4c_vars.hxx
@@ -540,9 +540,9 @@ template <typename T> struct z4c_vars : z4c_vars_noderivs<T> {
         ZtC([&](int a) ARITH_INLINE { return (Gamt(a) - Gamtd(a)) / 2; }), //
         // (14)
         HC(Rsc //
-           + sum_symm<3>([&](int x, int y)
+           - sum_symm<3>([&](int x, int y)
                              ARITH_INLINE { return At(x, y) * Atu(x, y); }) //
-           - 2 / T(3) * pow2(Kh + 2 * Theta)                                //
+           + 2 / T(3) * pow2(Kh + 2 * Theta)                                //
            - 16 * T(M_PI) * rho),
         // (15)
         MtC([&](int a) ARITH_INLINE {
@@ -554,7 +554,7 @@ template <typename T> struct z4c_vars : z4c_vars_noderivs<T> {
                      return (delta3(a, x) + gammatu(a, x)) *
                             (dKh(x) + 2 * dTheta(x));
                    }) //
-                 - 2 / T(3) * sum<3>([&](int x) ARITH_INLINE {
+                 - 3 / T(2) * sum<3>([&](int x) ARITH_INLINE {
                      return Atu(a, x) * dchi(x) / (1 + chi);
                    }) //
                  - 8 * T(M_PI) * sum<3>([&](int x) ARITH_INLINE {

--- a/Z4c/src/z4c_vars.hxx
+++ b/Z4c/src/z4c_vars.hxx
@@ -538,6 +538,9 @@ template <typename T> struct z4c_vars : z4c_vars_noderivs<T> {
         // Constraints
         // (13)
         ZtC([&](int a) ARITH_INLINE { return (Gamt(a) - Gamtd(a)) / 2; }), //
+        // For the Hamiltonian and momentum constraints, the equations in
+        // 1212.2901 is incorrect, whereas the one in 0912.2920 is correct,
+        // as double-checked by Liwei Ji.
         // (14)
         HC(Rsc //
            - sum_symm<3>([&](int x, int y)


### PR DESCRIPTION
This typo is coming from
https://arxiv.org/pdf/1212.2901
The correct ones are here
https://arxiv.org/abs/0912.2920