### PR TITLE
TwoPuncturesX: Support slow start lapse

### DIFF
--- a/TwoPuncturesX/param.ccl
+++ b/TwoPuncturesX/param.ccl
@@ -11,7 +11,8 @@ EXTENDS KEYWORD initial_lapse
 {
   "twopunctures-antisymmetric" :: "antisymmetric lapse for two puncture black holes, -1 <= alpha <= +1"
   "twopunctures-averaged"      :: "averaged lapse for two puncture black holes, 0 <= alpha <= +1"
-  "psi^n"                      :: "Based on the initial conformal factor"
+  "psi^n"                      :: "Based on the initial uncorrected conformal factor psi, not psi+u"
+  "W"                          :: "Evolved variable W=(psi+u)^{-2}, needed for slow-start lapse; see arXiv:2404.01137, Phys. Rev. D 110, 064045 (2024)"
   "brownsville"                :: "See Phys. Rev. D 74, 041501 (2006)"
 }
 


### PR DESCRIPTION
This is a byte by byte copy of the `TwoPunctures` fix implemented [here](https://bitbucket.org/einsteintoolkit/tickets/issues/2887/twopunctures-does-not-support-slow-start), enabling `TwoPuncturesX` to work correctly with evolution codes that support Slow Start Lapse slicing.

For more details, see the original `TwoPunctures` fix commit hash [here](https://bitbucket.org/einsteintoolkit/einsteininitialdata/commits/3d014938cc6165a80caeb53b66f814452cc34f89)